### PR TITLE
Add iputils-ping package

### DIFF
--- a/docker/strong-pm/Dockerfile
+++ b/docker/strong-pm/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get install -y vim
 RUN apt-get install -y procps
 RUN apt-get install -y curl
 RUN apt-get install -y python
+RUN apt-get install -y iputils-ping
 
 RUN curl -sL https://deb.nodesource.com/setup | bash -
 RUN apt-get install -y nodejs


### PR DESCRIPTION
adds plain ol' `ping` util for network connectivity testing. for instance, we need it to test for access to an elasticsearch instance.